### PR TITLE
TST: stats.sf/isf: add strong, generic test

### DIFF
--- a/scipy/stats/tests/test_continuous_basic.py
+++ b/scipy/stats/tests/test_continuous_basic.py
@@ -168,6 +168,8 @@ def test_cont_basic(distname, arg, sn, n_fit_samples):
         check_sample_meanvar_(m, v, rvs)
     check_cdf_ppf(distfn, arg, distname)
     check_sf_isf(distfn, arg, distname)
+    check_cdf_sf(distfn, arg, distname)
+    check_ppf_isf(distfn, arg, distname)
     check_pdf(distfn, arg, distname)
     check_pdf_logpdf(distfn, arg, distname)
     check_pdf_logpdf_at_endpoints(distfn, arg, distname)
@@ -586,10 +588,20 @@ def check_sf_isf(distfn, arg, msg):
     npt.assert_almost_equal(distfn.sf(distfn.isf([0.1, 0.5, 0.9], *arg), *arg),
                             [0.1, 0.5, 0.9], decimal=DECIMAL, err_msg=msg +
                             ' - sf-isf roundtrip')
+
+
+def check_cdf_sf(distfn, arg, msg):
     npt.assert_almost_equal(distfn.cdf([0.1, 0.9], *arg),
                             1.0 - distfn.sf([0.1, 0.9], *arg),
                             decimal=DECIMAL, err_msg=msg +
                             ' - cdf-sf relationship')
+
+
+def check_ppf_isf(distfn, arg, msg):
+    p = np.array([0.1, 0.9])
+    npt.assert_almost_equal(distfn.isf(p, *arg), distfn.ppf(1-p, *arg),
+                            decimal=DECIMAL, err_msg=msg +
+                            ' - ppf-isf relationship')
 
 
 def check_pdf(distfn, arg, msg):

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9335,7 +9335,8 @@ class TestTruncPareto:
 
 
 @pytest.mark.parametrize("case", [("loglaplace", None, None, None),
-                                  ("lognorm", None, None, None),])
+                                  ("lognorm", None, None, None),
+                                  ("pareto", None, None, None),])
 def test_generic_sf_isf(case):
     distname, domain, atol, rtol = case
     domain = domain or (-290, 0)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9334,19 +9334,34 @@ class TestTruncPareto:
             _assert_less_or_close_loglike(stats.truncpareto, data, **kwds)
 
 
-@pytest.mark.parametrize("case", [("loglaplace", None, None, None),
-                                  ("lognorm", None, None, None),
-                                  ("pareto", None, None, None),])
+# Cases are (distribution name, log10 of smallest probability mass to test,
+# log10 of the complement of the largest probability mass to test, atol,
+# rtol). None uses default values.
+@pytest.mark.parametrize("case", [("loglaplace", None, None, None, None),
+                                  ("lognorm", None, None, None, None),
+                                  ("pareto", None, None, None, None),])
 def test_sf_isf_overrides(case):
-    # A stronger test that supplements `test_continuous_basic.check_sf_isf`
-    # for distributions with overridden `sf` and `isf` methods.
-    distname, domain, atol, rtol = case
-    domain = domain or (-290, 0)
+    # Test that SF is the inverse of ISF. Supplements
+    # `test_continuous_basic.check_sf_isf` for distributions with overridden
+    # `sf` and `isf` methods.
+    distname, lp1, lp2, atol, rtol = case
+
+    lpm = np.log10(0.5)  # log10 of the probability mass at the median
+    lp1 = lp1 or -290
+    lp2 = lp2 or -14
     atol = atol or 0
     rtol = rtol or 1e-12
     dist = getattr(stats, distname)
     params = dict(distcont)[distname]
     dist_frozen = dist(*params)
-    ref = np.logspace(*domain)
+
+    # Test (very deep) right tail to median. We can benchmark with random
+    # (loguniform) points, but strictly logspaced points are fine for tests.
+    ref = np.logspace(lp1, lpm)
+    res = dist_frozen.sf(dist_frozen.isf(ref))
+    assert_allclose(res, ref, atol=atol, rtol=rtol)
+
+    # test median to left tail
+    ref = 1 - np.logspace(lp2, lpm, 20)
     res = dist_frozen.sf(dist_frozen.isf(ref))
     assert_allclose(res, ref, atol=atol, rtol=rtol)

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9337,7 +9337,9 @@ class TestTruncPareto:
 @pytest.mark.parametrize("case", [("loglaplace", None, None, None),
                                   ("lognorm", None, None, None),
                                   ("pareto", None, None, None),])
-def test_generic_sf_isf(case):
+def test_sf_isf_overrides(case):
+    # A stronger test that supplements `test_continuous_basic.check_sf_isf`
+    # for distributions with overridden `sf` and `isf` methods.
     distname, domain, atol, rtol = case
     domain = domain or (-290, 0)
     atol = atol or 0

--- a/scipy/stats/tests/test_distributions.py
+++ b/scipy/stats/tests/test_distributions.py
@@ -9332,3 +9332,18 @@ class TestTruncPareto:
                 stats.truncpareto.fit(data, **kwds)
         else:
             _assert_less_or_close_loglike(stats.truncpareto, data, **kwds)
+
+
+@pytest.mark.parametrize("case", [("loglaplace", None, None, None),
+                                  ("lognorm", None, None, None),])
+def test_generic_sf_isf(case):
+    distname, domain, atol, rtol = case
+    domain = domain or (-290, 0)
+    atol = atol or 0
+    rtol = rtol or 1e-12
+    dist = getattr(stats, distname)
+    params = dict(distcont)[distname]
+    dist_frozen = dist(*params)
+    ref = np.logspace(*domain)
+    res = dist_frozen.sf(dist_frozen.isf(ref))
+    assert_allclose(res, ref, atol=atol, rtol=rtol)


### PR DESCRIPTION
#### Reference issue
gh-18820

#### What does this implement/fix?
The intent here is to add a strong, generic test of the SF/ISF relationship so that you don't need to create reference distributions just to override the ISF method.

Please check the changes to the tests, and if they look good to you, merge them into your branch. I will merge the PR into SciPy, and then I'd ask you merge main into your other PRs (and, if you're willing, remove the reference distributions) before I review them.

@dschmitz89 please take a look, too.